### PR TITLE
Workspace-cleaning endpoint in the `che-tenant-maintainer` dsaas service

### DIFF
--- a/source/io/fabric8/tenant/che/migration/namespace/NamespaceMigration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/NamespaceMigration.ceylon
@@ -71,7 +71,7 @@ shared abstract class NamespaceMigration(
     shared formal String name;
 
     shared restricted(`module`) String osioCheNamespace(OpenShiftClient oc) =>
-            if (!osNamespace.empty) then osNamespace else oc.namespace;
+            if (!osNamespace.empty) then osNamespace else (oc.namespace else "default");
 
     shared formal Status migrate();
 

--- a/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
@@ -71,7 +71,7 @@ shared class Migration(
         String requestId = "",
         String jobRequestId = "",
         String osNamespace = environment.osNamespace else "",
-        String osToken = environment.osToken else "",
+        String osToken = environment.osToken else keycloakToken,
         Boolean debugLogs = environment.debugLogs
 
         ) extends NamespaceMigration(identityId, requestId, jobRequestId, osNamespace, osToken, debugLogs) {
@@ -171,7 +171,7 @@ shared class Migration(
                                 log.info(() => " Removing the workspace definition of the following newly created workspaces: ``
                                 toRollback.map(Entry.item) ``");
 
-                                toRollback.each(migrator.rollbackCreatedWorkspace);
+                                toRollback.each(curry(migrator.deleteWorkspace)(destinationCheServer));
                                 status = Status(1, message, statusForWorkspaces.migratedWorkspaces);
                                 break;
                             }

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Endpoint.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Endpoint.ceylon
@@ -1,0 +1,44 @@
+import javax.ws.rs {
+    path,
+    get,
+    produces,
+    consumes,
+    post
+}
+import javax.ws.rs.core {
+    MediaType,
+    context,
+    UriInfo,
+    HttpHeaders
+}
+import io.fabric8.tenant.che.migration.namespace {
+    MigrationEndpoint,
+    Status,
+    environment
+}
+
+path(Name.name)
+shared class Endpoint() extends MigrationEndpoint<Maintenance>() {
+
+    endpointName => Name.name;
+
+    completeArguments(HttpHeaders headers) => super.completeArguments(headers).chain {
+        if (exists cheServer = environment.cheDestinationServer)
+        then "che-server" -> cheServer else null
+    }.coalesced;
+
+    post
+    produces {MediaType.applicationJson}
+    consumes {MediaType.applicationJson}
+    shared actual Status post(context HttpHeaders headers, String json) => super.post(headers, json);
+
+    get
+    produces {MediaType.applicationJson}
+    shared actual Status get(context HttpHeaders headers, context UriInfo info) => super.get(headers, info);
+
+    get
+    path("help")
+    produces {MediaType.textPlain}
+    shared actual String help() => super.help();
+}
+

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Maintenance.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Maintenance.ceylon
@@ -1,0 +1,329 @@
+import fr.minibilles.cli {
+    option
+}
+
+import io.fabric8.kubernetes.api.model {
+    PersistentVolumeClaimVolumeSourceBuilder,
+    VolumeBuilder,
+    VolumeMountBuilder
+}
+import io.fabric8.kubernetes.client {
+    KubernetesClientException
+}
+import io.fabric8.openshift.client {
+    DefaultOpenShiftClient,
+    OpenShiftClient
+}
+import io.fabric8.tenant.che.migration.namespace {
+    ...
+}
+import io.fabric8.tenant.che.migration.workspaces {
+    log,
+    WorkspaceTool = Tool,
+    WorkspaceStatus=Status
+}
+import java.lang {
+    Thread {
+        sleep
+    }
+}
+import java.util {
+    Arrays
+}
+import ceylon.json {
+    JsonObject
+}
+
+Boolean() buildTimeout(Integer timeout) {
+    value end = system.milliseconds + timeout;
+    return () => system.milliseconds > end;
+}
+
+shared Maintenance withDefaultValues() => Maintenance(
+    environment.cheDestinationServer else "",
+    environment.osioToken else "",
+    false,
+    false,
+    environment.identityId else "",
+    environment.requestId else "",
+    environment.jobRequestId else "",
+    environment.osNamespace else "",
+    environment.osToken else "",
+    environment.debugLogs
+);
+
+"
+ This utility will clean the user workspace-dedicated
+ persistent volume from workspace directories
+ that don't correspond to a workspace in the Che user account.
+
+ It also provides an option to delete all the Che workspaces
+ of the user before cleaning workspace files, in order to fully
+ cleanup the user Che tenant.
+ "
+shared class Maintenance(
+
+        "
+         API Url of the Che server that contains workspaces to clean.
+
+         For example: `https://che.openshift.io/api`
+         "
+        option("che-server", 's')
+        shared String cheServer,
+
+        "
+         Keycloak (OSIO) token of the user that will be migrated
+         "
+        option("token", 't')
+        shared String keycloakToken,
+
+        "
+         Also stop and delete the existing workspaces before cleaning workspace directories
+         "
+        option("delete-all-workspaces", 'd')
+        shared Boolean deleteAllWorkspaces = false,
+
+        "
+         Only simulate the cleaning but don't apply it
+
+         Note that when compined with the `delete-all-workspaces`
+         option, the running workspaces will still be stopped,
+         but not deleted.
+         "
+        option("dry-run", 'z')
+        shared Boolean dryRun = false,
+
+        String identityId = "",
+        String requestId = "",
+        String jobRequestId = "",
+        String osNamespace = environment.osNamespace else "",
+        String osToken = environment.osToken else keycloakToken,
+        Boolean debugLogs = environment.debugLogs
+
+        ) extends NamespaceMigration(identityId, requestId, jobRequestId, osNamespace, osToken, debugLogs) {
+
+    name = Name.name;
+
+    function error(String message) {
+        log.error(message);
+        return Status(1, message);
+    }
+
+    shared actual Status migrate() {
+        value workspaceTool = WorkspaceTool(keycloakToken);
+        value listWorkspaces = curry(workspaceTool.listWorkspaces)(cheServer);
+        value getWorkspace = curry(workspaceTool.getWorkspace)(cheServer);
+        value getId = workspaceTool.getId;
+        value isStopped = workspaceTool.isStopped;
+        value stopWorkspace = curry(workspaceTool.stopWorkspace)(cheServer);
+        value deleteWorkspace = curry(workspaceTool.deleteWorkspace)(cheServer);
+
+        try(oc = DefaultOpenShiftClient(osConfig)) {
+            value namespace = osioCheNamespace(oc);
+
+            value lockConfigMap = "maintenance-lock";
+            value lockResources = oc.configMaps().inNamespace(namespace).withName(lockConfigMap);
+            if(lockResources.get() exists) {
+                log.info("A previous maintenance Job is already running. Waiting for it to finish...");
+            }
+
+            value timeoutMinutes = 10;
+            for(retry in 0:timeoutMinutes*60) {
+                if(! lockResources.get() exists) {
+                    try {
+                        if (lockResources.createNew().withNewMetadata().withName(lockConfigMap).endMetadata().done() exists) {
+                            break;
+                        }
+                    } catch(Exception e) {
+                        if (is KubernetesClientException e,
+                            exists reason = e.status.reason,
+                            reason == "AlreadyExists") {
+                            log.debug("Lock config map already exists. Waiting for it to be released");
+                        } else {
+                            log.warn("Exception when trying to create the lock config map", e);
+                        }
+                    }
+                }
+                sleep(1000);
+            } else {
+                return error("The maintenance lock is still owned, even after a ``timeoutMinutes`` minutes in namespace '`` namespace ``'
+                                 It might be necessary to remove the 'maintenance-lock' config map manually.");
+            }
+
+            try {
+                value workspaces = listWorkspaces();
+                if (is WorkspaceStatus workspaces) {
+                    return Status(1, workspaces.string);
+                }
+
+                {String*} workspaceIdsToKeep;
+                if(deleteAllWorkspaces) {
+                    for (wksp in workspaces) {
+                        value id = getId(wksp);
+                        if (! isStopped(wksp)) {
+                            if (!stopWorkspace(wksp)) {
+                                return error("The workspace `` id `` could not be stopped in namespace '`` namespace ``'");
+                            }
+                            value timeoutSeconds = 30;
+                            value stopTimedOut = buildTimeout(timeoutSeconds * 1000);
+                            value hasStopped =>
+                                    if (is JsonObject w = getWorkspace(id)) then isStopped(w) else false;
+
+                            while (! hasStopped) {
+                                if (stopTimedOut()) {
+                                    return error("The workspace `` id `` cannot be stopped, even after a `` timeoutSeconds `` seconds in namespace '`` namespace ``'");
+                                }
+                                sleep(1000);
+                            }
+                        }
+                        if (dryRun) {
+                            log.info(()=> "should delete workspace `` id `` (dry run)");
+                            continue;
+                        }
+                        if (!deleteWorkspace(wksp)) {
+                            return error("The workspace `` id `` could not be deleted in namespace '`` namespace ``'");
+                        }
+                    }
+
+                    workspaceIdsToKeep = {};
+                } else {
+                    workspaceIdsToKeep = workspaces.map(getId);
+                }
+
+                Status status;
+                value [code, stderr] = cleanWorkspaceFiles(oc, workspaceIdsToKeep);
+                if (exists code,
+                    code == 0) {
+                    log.info(() => "Workspace files correctly cleaned");
+                    status = Status(0, "");
+                } else {
+                    value detailedLog =
+                    if (exists code)
+                    then "Command failed with the following code: `` code `` and termination message: `` stderr else "" ``"
+                    else (stderr else "");
+
+                    String message = "Failure during cleaning of workspace files: `` detailedLog ``";
+                    log.error(" => `` message ``");
+
+                    status = Status(1, message, "");
+                }
+
+                if (status.code == 0) {
+                    log.info(status.message);
+                } else {
+                    log.error(status.message);
+                }
+                return status;
+            } catch(Exception e){
+                value message = "Unexpected exception while migrating namespace `` namespace ``";
+                log.error(message, e);
+                return Status(1, "`` message ``: `` e.message ``");
+            } finally {
+                lockResources.delete();
+            }
+        }
+    }
+
+    [Integer?,String?] cleanWorkspaceFiles(OpenShiftClient oc, {String*} workspacesIdsToKeep) {
+
+        value podName = "workspace-data-cleaning-`` if (requestId.empty) then system.milliseconds / 1000 else requestId.replace("-", "") ``";
+        value claimName = "claim-che-workspace";
+
+        if (! oc.persistentVolumeClaims().withName(claimName).get() exists) {
+            return [null, "PVC `` claimName `` doesn't exist !"];
+        }
+
+        value volumeName = "for-maintenance";
+
+        value volume =
+                VolumeBuilder()
+                    .withName(volumeName)
+                    .withPersistentVolumeClaim(
+                    PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName(claimName)
+                        .build())
+                    .build();
+
+        suppressWarnings("unusedDeclaration")
+        value pod = oc
+            .pods().createNew()
+            .withNewMetadata()
+            .withName(podName)
+            .endMetadata()
+            .withNewSpec()
+            .withRestartPolicy("Never")
+            .withVolumes(Arrays.asList(volume))
+            .addNewContainer()
+            .withName(podName)
+            .withImage("registry.access.redhat.com/rhel7-atomic")
+            .withImagePullPolicy("IfNotPresent")
+            .withVolumeMounts(Arrays.asList(*[
+            VolumeMountBuilder()
+                .withMountPath("/pvroot")
+                .withName(volumeName)
+                .build()
+        ]))
+            .withCommand(
+                "/bin/bash",
+                "-c",
+                " ".join{
+                    "eval 'set -e; for file in $(ls /pvroot); do",
+                    "case $file in",
+                    if (workspacesIdsToKeep.empty)
+                    then ""
+                    else "`` "|".join(workspacesIdsToKeep) ``) echo \"keeping $file\";;",
+                    "*)",
+                    if (dryRun)
+                    then """echo "should remove ${file} (dry run)";;"""
+                    else """echo "removing $file"; rm -Rf "/pvroot/$file";;""",
+                    "esac;",
+                    "done' 2> /dev/termination-log"
+                }
+            )
+            .endContainer()
+            .endSpec()
+            .done();
+
+        function terminated() {
+            if (exists pod = oc.pods()
+                .withName(podName)
+                .get(),
+                exists containerStatuses = pod.status?.containerStatuses,
+                containerStatuses.size() > 0,
+                exists status = containerStatuses.get(0),
+                exists terminated = status.state?.terminated) {
+                return terminated;
+            }
+            return null;
+        }
+
+        value commandTimedOut = buildTimeout(60000);
+        variable value status = terminated();
+
+        while(! status exists) {
+            if (commandTimedOut()) {
+                break;
+            }
+            sleep(1000);
+            status = terminated();
+        }
+
+        if (exists terminationStatus = status) {
+            return [
+                terminationStatus.exitCode.intValue(),
+                terminationStatus.message of String?
+            ];
+        } else {
+            if (exists pendingPod = oc.pods()
+                .withName(podName)
+                .get(),
+                exists phase = pendingPod.status?.phase,
+                phase == "Pending") {
+                    oc.pods().withName(podName).delete();
+            }
+            
+            return  [null, "Timeout while waiting for container creation or command execution"];
+        }
+    }
+}
+

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Name.java
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Name.java
@@ -1,0 +1,5 @@
+package io.fabric8.tenant.che.migration.namespace.cleanWorkspaces;
+
+public interface Name {
+    public static final String name = "cleanWorkspaces";
+}

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/package.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/package.ceylon
@@ -1,0 +1,2 @@
+suppressWarnings("packageName")
+shared package io.fabric8.tenant.che.migration.namespace.cleanWorkspaces;

--- a/source/io/fabric8/tenant/che/migration/workspaces/Tool.ceylon
+++ b/source/io/fabric8/tenant/che/migration/workspaces/Tool.ceylon
@@ -1,0 +1,221 @@
+import java.util.concurrent {
+    TimeUnit
+}
+import okhttp3 {
+    Request { Http = Builder },
+    OkHttpClient,
+    RequestBody,
+    MediaType { contentType = parse },
+    Response
+}
+import ceylon.json {
+    JsonArray,
+    parseJSON=parse,
+    JsonValue=Value,
+    JsonObject
+}
+import java.net {
+    SocketTimeoutException
+}
+import java.lang {
+    Thread
+}
+
+shared class Tool(shared default String keycloakToken) {
+    value httpClient = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.seconds)
+        .readTimeout(30, TimeUnit.seconds)
+        .build();
+
+    value authorization => ["Authorization", "Bearer ``keycloakToken``"];
+
+    shared Response send(Http builder) => httpClient.newCall(builder
+        .header(*authorization)
+        .build()).execute();
+
+    shared Response get(String endpoint) => send(Http().get()
+        .url(endpoint));
+
+    shared Response postJson(String endpoint, String content) => send(Http()
+        .post(RequestBody.create(contentType("application/json"), content))
+        .url(endpoint));
+
+    shared Response delete(String endpoint) => send(Http().
+        delete().url(endpoint));
+
+    shared String workspaceEndpoint(String apiPath) => apiPath + "/workspace";
+
+    shared Status|{JsonObject*} listWorkspaces(String apiEndpoint) {
+        value sourceEndpoint = workspaceEndpoint(apiEndpoint);
+        log.debug(() => "Retrieving the list of workspaces from URL : `` sourceEndpoint `` ...");
+        JsonValue workspaces;
+        String? responseContents;
+        value timeoutMinutes = 2;
+        for(retry in 0:timeoutMinutes*60) {
+            try (response = get(sourceEndpoint)) {
+                switch(response.code())
+                case(200) {
+                    responseContents = response.body()?.string_method();
+                    break;
+                }
+                case(503) {
+                    log.debug("Che server (`` apiEndpoint ``) not accessible (error 503). Retrying ...");
+                    // Wait 1 second and retry
+                    Thread.sleep(1000);
+                }
+                else {
+                    return Status.unexpectedErrorInSourceCheServer(response);
+                }
+            } catch(SocketTimeoutException e) {
+                log.info("SocketTimeout exception when trying to access to the Che server (`` apiEndpoint ``). Retrying ...");
+                // Wait 1 second and retry
+                Thread.sleep(1000);
+            }
+        } else {
+            log.error("Che server not accessible even after ``timeoutMinutes`` minutes at '`` sourceEndpoint ``'");
+            return Status.sourceCheServerNotAccessible;
+        }
+        if (!exists responseContents) {
+            return Status.invalidJsonInWorkspaceList("<null>");
+        }
+
+        if (responseContents.empty) {
+            return Status.invalidJsonInWorkspaceList("");
+        }
+
+        log.debug(() => "    => `` responseContents ``");
+
+        try {
+            workspaces = parseJSON(responseContents);
+        } catch(Exception e) {
+            return Status.invalidJsonInWorkspaceList(responseContents);
+        }
+        if (! is JsonArray workspaces) {
+            return Status.invalidJsonInWorkspaceList(responseContents);
+        }
+        return workspaces.narrow<JsonObject>();
+    }
+
+    shared Status|JsonObject getWorkspace(String apiEndpoint, String id) {
+        value sourceEndpoint = "``workspaceEndpoint(apiEndpoint)``/``id``";
+        log.debug(() => "Retrieving the workspace description for id '`` id ``' from URL : `` sourceEndpoint `` ...");
+        JsonValue workspace;
+
+        String? responseContents;
+        value timeoutMinutes = 2;
+        for(retry in 0:timeoutMinutes*60) {
+            try (response = get(sourceEndpoint)) {
+                switch(response.code())
+                case(200) {
+                    responseContents = response.body()?.string_method();
+                    break;
+                }
+                case(503) {
+                    log.debug("Che server (`` apiEndpoint ``) not accessible (error 503). Retrying ...");
+                    // Wait 1 second and retry
+                    Thread.sleep(1000);
+                }
+                else {
+                    return Status.unexpectedErrorInSourceCheServer(response);
+                }
+            } catch(SocketTimeoutException e) {
+                log.info("SocketTimeout exception when trying to access to the Che server (`` apiEndpoint ``). Retrying ...");
+                // Wait 1 second and retry
+                Thread.sleep(1000);
+            }
+        } else {
+            log.error("Che server not accessible even after ``timeoutMinutes`` minutes at '`` sourceEndpoint ``'");
+            return Status.sourceCheServerNotAccessible;
+        }
+        if (!exists responseContents) {
+            return Status.invalidJsonInWorkspaceList("<null>");
+        }
+
+        if (responseContents.empty) {
+            return Status.invalidJsonInWorkspaceList("");
+        }
+
+        log.debug(() => "    => `` responseContents ``");
+
+        try {
+            workspace = parseJSON(responseContents);
+        } catch(Exception e) {
+            return Status.invalidJsonInWorkspaceList(responseContents);
+        }
+        if (! is JsonObject workspace) {
+            return Status.invalidJsonInWorkspaceList(responseContents);
+        }
+        return workspace;
+    }
+
+    shared Boolean deleteWorkspace(String apiEndpoint, JsonObject|<String->String?> workspace) {
+        value id->name = switch(workspace) case (is JsonObject) idAndName(workspace) else workspace;
+
+        value endpoint = "``workspaceEndpoint(apiEndpoint) ``/``id``";
+
+        try (response = delete(endpoint)) {
+            switch(response.code())
+            case(204) {
+                return true;
+            }
+            case(403) {
+                log.warn("User doesn't have right to remove workspace `` name else id ``");
+                return false;
+            }
+            case(409) {
+                log.warn("User cannot rollback the creation of workspace `` name else id`` since it's already running");
+                return false;
+            }
+            case(404) {
+                log.warn("User cannot rollback the creation of workspace `` name else id `` since it doesn't exist");
+                return false;
+            }
+            else {
+                log.warn("User cannot rollback the creation of workspace `` name else id ``: unexpected error");
+                return false;
+            }
+        }
+    }
+
+    shared Boolean stopWorkspace(String apiEndpoint, JsonObject|<String->String?> workspace) {
+        value id->name = switch(workspace) case (is JsonObject) idAndName(workspace) else workspace;
+
+        value endpoint = "``workspaceEndpoint(apiEndpoint)``/``id``/runtime";
+
+        try (response = delete(endpoint)) {
+            switch (response.code())
+            case (204) {
+                return true;
+            }
+            case (403) {
+                log.warn("User doesn't have right to stop workspace ``name else id``");
+                return false;
+            }
+            case (404) {
+                log.warn("User cannot stop workspace ``name else id`` since it doesn't exist");
+                return false;
+            }
+            else {
+                log.warn("User cannot stop workspace ``name else id``: unexpected error");
+                return false;
+            }
+        }
+    }
+
+    shared Boolean isStopped(JsonObject workspace) =>
+            if (exists status = workspace.getStringOrNull("status"))
+            then status == "STOPPED"
+            else false;
+
+    shared JsonObject getConfig(JsonObject workspace) =>
+            workspace.getObject("config");
+
+    shared String getName(JsonObject workspace) =>
+            getConfig(workspace).getString("name");
+
+    shared String getId(JsonObject workspace) =>
+            workspace.getString("id");
+
+    shared String->String idAndName(JsonObject workspace) =>
+            getId(workspace) -> getName(workspace);
+}


### PR DESCRIPTION
 Add the `cleanWorkspaces` endpoint to clean workspace directories and optionally delete all user workspaces from the Che server

This is related to issues redhat-developer/rh-che#481
and openshiftio/openshift.io#1614

More details on the endpoint and its parameters in the class documentation [here](https://github.com/fabric8-services/che-tenant-maintainer/blob/1701d9ecd16815094f05fc0ae4aabc22e3022569/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Maintenance.ceylon#L64) 