### PR TITLE
 Increasing workspace migration timeout to 3 minutes

### DIFF
--- a/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
@@ -277,7 +277,7 @@ shared class Migration(
             return null;
         }
 
-        value commandTimedOut = buildTimeout(60000);
+        value commandTimedOut = buildTimeout(180000);
         variable value status = terminated();
 
         while(! status exists) {


### PR DESCRIPTION
a dozen of tenants fail to migrate due to timeout. It would be nice to try to increase timeout & re-run migration script.

```
{"code":1,"message":"Failure during migration of workspace files for workspace test-tv9ix: Timeout while waiting for container creation or command execution","details":"{\"\":\"test\"}"}
migration took: 64 seconds
```