### PR TITLE
Enable build on RHEL

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,19 @@
+FROM prod.registry.devshift.net/osio-prod/base/jboss-jdk-8:latest
+
+ENV JAVA_HOME /etc/alternatives/jre
+ENV CHE_TENANT_MAINTAINER_HOME /opt/che-tenant-maintainer
+
+WORKDIR $CHE_TENANT_MAINTAINER_HOME
+
+COPY io.fabric8.tenant.che.migration.rest.jar ${CHE_TENANT_MAINTAINER_HOME}/
+COPY agent-bond/* ${CHE_TENANT_MAINTAINER_HOME}/agent-bond/
+COPY startRestEndpointsLocally.sh ${CHE_TENANT_MAINTAINER_HOME}/
+COPY jolokia-readonly-access.xml ${CHE_TENANT_MAINTAINER_HOME}/
+
+RUN chown -R 1000:0 ${CHE_TENANT_MAINTAINER_HOME} && chmod -R ug+rw ${CHE_TENANT_MAINTAINER_HOME}
+RUN chmod ug+x ${CHE_TENANT_MAINTAINER_HOME}/agent-bond/*
+
+EXPOSE 8080
+EXPOSE 8778
+
+ENTRYPOINT ["/opt/che-tenant-maintainer/startRestEndpointsLocally.sh"]

--- a/buildAndPushToDocker.sh
+++ b/buildAndPushToDocker.sh
@@ -4,9 +4,10 @@ set -e
 REGISTRY=${REGISTRY:-"docker.io"}
 NAMESPACE=${NAMESPACE:-"dfestal"}
 ADD_REST_ENDPOINTS=${ADD_REST_ENDPOINTS:-false}
+DOCKERFILE=${DOCKERFILE:-"Dockerfile"}
 
 function tag_push() {
-  TARGET=$1
+  local TARGET=$1
   docker tag f8tenant-che-migration-deploy $TARGET
   docker push $TARGET
 }
@@ -15,7 +16,7 @@ if [ "$S2I_BUILD" == "true" ]; then
   s2i build -e ADD_REST_ENDPOINTS="${ADD_REST_ENDPOINTS}" -c . ceylon/s2i-ceylon:1.3.3-jre8 f8tenant-che-migration-deploy
 else
   ./buildLocally.sh
-  docker build -t f8tenant-che-migration-deploy .
+  docker build -t f8tenant-che-migration-deploy -f ${DOCKERFILE} .
 fi
 
 

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -6,7 +6,16 @@ set -x
 # Exit on error
 set -e
 
-REGISTRY=${REGISTRY:-"push.registry.devshift.net"}
+# TARGET variable gives ability to switch context for building rhel based images, default is "centos"
+# If CI slave is configured with TARGET="rhel" RHEL based images should be generated then.
+TARGET=${TARGET:-"centos"}
+if [ $TARGET == "rhel" ]; then
+  DOCKERFILE="Dockerfile.rhel"
+  REGISTRY=${DOCKER_REGISTRY:-"push.registry.devshift.net/osio-prod"}
+else
+  REGISTRY=${REGISTRY:-"push.registry.devshift.net"}
+  DOCKERFILE="Dockerfile"
+fi
 NAMESPACE=${NAMESPACE:-"fabric8-services"}
 
 # Source environment variables of the jenkins slave
@@ -30,7 +39,7 @@ function login() {
 }
 
  # We need to disable selinux for now, XXX
-/usr/sbin/setenforce 0
+/usr/sbin/setenforce 0 || true
 
 # Get all the deps in
 yum -y install \

--- a/openshift/che-tenant-maintainer.app.yml
+++ b/openshift/che-tenant-maintainer.app.yml
@@ -88,7 +88,7 @@ objects:
       app: che-tenant-maintainer
 parameters:
 - name: IMAGE
-  value: "registry.devshift.net/fabric8-services/fabric8-tenant-che-migration"
+  value: "prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-tenant-che-migration"
 - name: IMAGE_TAG
   value: "latest"
 - description: Add DEBUG logs


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.
cc: @l0rd @davidfestal @jmelis