### PR TITLE
Adapt the `che-tenant-maintainer` to the last oso proxy changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /modules/
+/classes/
 /.exploded/
 /io.fabric8.tenant.che.migration.rest-*.war
 /io.fabric8.tenant.che.migration.rest.jar

--- a/fabric8-tenant-che-migration.iml
+++ b/fabric8-tenant-che-migration.iml
@@ -29,23 +29,28 @@
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: ceylon.logging/1.3.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: ceylon.regex/1.3.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: ceylon.time/1.3.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.core:jackson-annotations/2.7.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.core:jackson-core/2.7.7" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.core:jackson-databind/2.7.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.core:jackson-annotations/2.8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.core:jackson-core/2.8.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.core:jackson-databind/2.8.9" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.dataformat:jackson-dataformat-yaml/2.7.7" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.fasterxml.jackson.module:jackson-module-jaxb-annotations/2.7.5" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.github.mifmif:generex/1.0.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.squareup.okhttp3:logging-interceptor/3.8.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.squareup.okhttp3:okhttp/3.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.google.code.gson:gson/2.8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.sangupta:murmur/1.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.squareup.okhttp3:logging-interceptor/3.9.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.squareup.okhttp3:okhttp/3.9.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: com.squareup.okio:okio/1.13.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: dk.brics.automaton:automaton/1.11-8" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: fr.minibilles.cli/0.3.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.fabric8:kubernetes-client/2.6.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.fabric8:kubernetes-model/1.1.4" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.fabric8:openshift-client/2.6.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.fabric8:kubernetes-client/3.1.12" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.fabric8:kubernetes-model/2.0.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.fabric8:openshift-client/3.1.12" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.fabric8:zjsonpatch/0.3.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: io.jsonwebtoken:jjwt/0.9.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: javax.validation:validation-api/1.1.0.Final" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: javax.ws.rs:javax.ws.rs-api/2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: no.finn.unleash:unleash-client-java/3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.apache.logging.log4j:log4j-api/2.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.slf4j:jul-to-slf4j/1.7.13" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.slf4j:slf4j-api/1.7.13" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Ceylon: org.slf4j:slf4j-nop/1.7.13" level="project" />

--- a/source/io/fabric8/tenant/che/migration/namespace/NamespaceMigration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/NamespaceMigration.ceylon
@@ -1,30 +1,30 @@
 import ceylon.file {
-    File,
-    parsePath,
-    Nil
+	File,
+	parsePath,
+	Nil
 }
 import ceylon.logging {
-    debug,
-    info
+	debug,
+	info
 }
 
 import fr.minibilles.cli {
-    option
+	option
 }
 
 import io.fabric8.openshift.client {
-    DefaultOpenShiftClient,
-    OpenShiftClient,
-    OpenShiftConfigBuilder,
-    OpenShiftConfig
+	DefaultOpenShiftClient,
+	OpenShiftClient,
+	OpenShiftConfigBuilder,
+	OpenShiftConfig
 }
 import io.fabric8.tenant.che.migration.workspaces {
-    logSettings,
-    log
+	logSettings,
+	log
 }
 
 import java.lang {
-    JavaString=String
+	JavaString=String
 }
 
 shared abstract class NamespaceMigration(
@@ -51,8 +51,9 @@ shared abstract class NamespaceMigration(
 
         "debug"
         option("debug-logs", 'v')
-        shared Boolean debugLogs = environment.debugLogs
-
+        shared Boolean debugLogs = environment.debugLogs,
+        
+        void configOverride(OpenShiftConfig conf) => noop()
         ) {
 
     value builder = OpenShiftConfigBuilder();
@@ -67,6 +68,7 @@ shared abstract class NamespaceMigration(
     }
 
     shared OpenShiftConfig osConfig = builder.build();
+    configOverride(osConfig);
 
     shared formal String name;
 

--- a/source/io/fabric8/tenant/che/migration/namespace/NamespaceMigration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/NamespaceMigration.ceylon
@@ -1,30 +1,30 @@
 import ceylon.file {
-	File,
-	parsePath,
-	Nil
+    File,
+    parsePath,
+    Nil
 }
 import ceylon.logging {
-	debug,
-	info
+    debug,
+    info
 }
 
 import fr.minibilles.cli {
-	option
+    option
 }
 
 import io.fabric8.openshift.client {
-	DefaultOpenShiftClient,
-	OpenShiftClient,
-	OpenShiftConfigBuilder,
-	OpenShiftConfig
+    DefaultOpenShiftClient,
+    OpenShiftClient,
+    OpenShiftConfigBuilder,
+    OpenShiftConfig
 }
 import io.fabric8.tenant.che.migration.workspaces {
-	logSettings,
-	log
+    logSettings,
+    log
 }
 
 import java.lang {
-	JavaString=String
+    JavaString=String
 }
 
 shared abstract class NamespaceMigration(

--- a/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/che5ToChe6/Migration.ceylon
@@ -53,6 +53,7 @@ shared Migration withDefaultValues() => Migration(
 
 "This utility will try to migrate the user's
  Che 5 workspaces into the new Che 6 server"
+migrationFinished
 shared class Migration(
 
         "Url of the Che 5 server that contains workspaces to migrate"

--- a/source/io/fabric8/tenant/che/migration/namespace/cheServiceAccountToggle.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cheServiceAccountToggle.ceylon
@@ -1,0 +1,81 @@
+import com.google.gson {
+	JsonParser
+}
+
+import io.fabric8.tenant.che.migration.workspaces {
+	log
+}
+
+import no.finn.unleash {
+	DefaultUnleash,
+	UnleashContext {
+		contextBuilder=builder
+	}
+}
+import no.finn.unleash.util {
+	UnleashConfig {
+		Builder
+	}
+}
+
+import okhttp3 {
+	FormBody,
+	Request,
+	OkHttpClient
+}
+
+shared object cheServiceAccountTokenManager {
+	
+	value unleash = DefaultUnleash(object extends Builder() {
+			appName("rh-che");
+			unleashAPI(process.environmentVariableValue("F8_TOGGLES_API") else "http://f8toggles/api");
+			instanceId(
+				if (exists envVar = process.environmentVariableValue("HOSTNAME"),
+					!envVar.empty)
+				then envVar
+				else "che-host");
+		}.build());
+	
+	"Id of the Che service account used by the `fabric8_oso_proxy` to secure user namespaces"
+	value serviceAccountId = environment.serviceAccountId;
+	
+	"Secret of the Che service account used by the `fabric8_oso_proxy` to secure user namespaces"
+	value serviceAccountSecret = environment.serviceAccountSecret;
+	
+	"URL of the `fabric8_auth` service"
+	value authApiUrl = environment.authApiUrl else "http://auth:8089";
+	
+	shared String? token;
+	
+	if (exists serviceAccountId,
+		!serviceAccountId.empty,
+		exists serviceAccountSecret,
+		!serviceAccountSecret.empty) {
+		log.info("Retrieving the Che service account from the 'fabric8_auth' endpoint");
+	} else {
+		token = null;
+		return;
+	}
+	
+	value client = OkHttpClient();
+	value requestBody = FormBody.Builder()
+		.add("grant_type", "client_credentials")
+		.add("client_id", serviceAccountId)
+		.add("client_secret", serviceAccountSecret)
+		.build();
+	
+	value request = Request.Builder().url(authApiUrl + "/token").post(requestBody).build();
+	
+	try (response = client.newCall(request).execute()) {
+		token = JsonParser()
+			.parse(response.body()?.string_method())
+			.asJsonObject
+			.get("access_token")
+			.asString;
+		
+		log.info("Che Service account token has been successfully retrieved");
+	}
+	
+	shared Boolean useCheServiceAccountToken(String userId) =>
+		unleash.isEnabled("che.serviceaccount.lockdown", contextBuilder().userId(userId).build());
+}

--- a/source/io/fabric8/tenant/che/migration/namespace/cheServiceAccountToggle.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cheServiceAccountToggle.ceylon
@@ -1,81 +1,78 @@
 import com.google.gson {
-	JsonParser
+    JsonParser
 }
-
 import io.fabric8.tenant.che.migration.workspaces {
-	log
+    log
 }
-
 import no.finn.unleash {
-	DefaultUnleash,
-	UnleashContext {
-		contextBuilder=builder
-	}
+    DefaultUnleash,
+    UnleashContext {
+        contextBuilder=builder
+    }
 }
 import no.finn.unleash.util {
-	UnleashConfig {
-		Builder
-	}
+    UnleashConfig {
+        Builder
+    }
 }
-
 import okhttp3 {
-	FormBody,
-	Request,
-	OkHttpClient
+    FormBody,
+    Request,
+    OkHttpClient
 }
 
 shared object cheServiceAccountTokenManager {
-	
-	value unleash = DefaultUnleash(object extends Builder() {
-			appName("rh-che");
-			unleashAPI(process.environmentVariableValue("F8_TOGGLES_API") else "http://f8toggles/api");
-			instanceId(
-				if (exists envVar = process.environmentVariableValue("HOSTNAME"),
-					!envVar.empty)
-				then envVar
-				else "che-host");
-		}.build());
-	
-	"Id of the Che service account used by the `fabric8_oso_proxy` to secure user namespaces"
-	value serviceAccountId = environment.serviceAccountId;
-	
-	"Secret of the Che service account used by the `fabric8_oso_proxy` to secure user namespaces"
-	value serviceAccountSecret = environment.serviceAccountSecret;
-	
-	"URL of the `fabric8_auth` service"
-	value authApiUrl = environment.authApiUrl else "http://auth:8089";
-	
-	shared String? token;
-	
-	if (exists serviceAccountId,
-		!serviceAccountId.empty,
-		exists serviceAccountSecret,
-		!serviceAccountSecret.empty) {
-		log.info("Retrieving the Che service account from the 'fabric8_auth' endpoint");
-	} else {
-		token = null;
-		return;
-	}
-	
-	value client = OkHttpClient();
-	value requestBody = FormBody.Builder()
-		.add("grant_type", "client_credentials")
-		.add("client_id", serviceAccountId)
-		.add("client_secret", serviceAccountSecret)
-		.build();
-	
-	value request = Request.Builder().url(authApiUrl + "/token").post(requestBody).build();
-	
-	try (response = client.newCall(request).execute()) {
-		token = JsonParser()
-			.parse(response.body()?.string_method())
-			.asJsonObject
-			.get("access_token")
-			.asString;
-		
-		log.info("Che Service account token has been successfully retrieved");
-	}
-	
-	shared Boolean useCheServiceAccountToken(String userId) =>
-		unleash.isEnabled("che.serviceaccount.lockdown", contextBuilder().userId(userId).build());
+    
+    value unleash = DefaultUnleash(object extends Builder() {
+            appName("rh-che");
+            unleashAPI(process.environmentVariableValue("F8_TOGGLES_API") else "http://f8toggles/api");
+            instanceId(
+                if (exists envVar = process.environmentVariableValue("HOSTNAME"),
+                    !envVar.empty)
+                then envVar
+                else "che-host");
+        }.build());
+    
+    "Id of the Che service account used by the `fabric8_oso_proxy` to secure user namespaces"
+    value serviceAccountId = environment.serviceAccountId;
+    
+    "Secret of the Che service account used by the `fabric8_oso_proxy` to secure user namespaces"
+    value serviceAccountSecret = environment.serviceAccountSecret;
+    
+    "URL of the `fabric8_auth` service"
+    value authApiUrl = environment.authApiUrl else "http://auth:8089";
+    
+    shared String? token;
+    
+    if (exists serviceAccountId,
+        !serviceAccountId.empty,
+        exists serviceAccountSecret,
+        !serviceAccountSecret.empty) {
+        log.info("Retrieving the Che service account from the 'fabric8_auth' endpoint");
+    } else {
+        token = null;
+        return;
+    }
+    
+    value client = OkHttpClient();
+    value requestBody = FormBody.Builder()
+        .add("grant_type", "client_credentials")
+        .add("client_id", serviceAccountId)
+        .add("client_secret", serviceAccountSecret)
+        .build();
+    
+    value request = Request.Builder().url(authApiUrl + "/token").post(requestBody).build();
+    
+    try (response = client.newCall(request).execute()) {
+        token = JsonParser()
+            .parse(response.body()?.string_method())
+            .asJsonObject
+            .get("access_token")
+            .asString;
+        
+        log.info("Che Service account token has been successfully retrieved");
+    }
+    
+    shared Boolean useCheServiceAccountToken(String userId) =>
+        unleash.isEnabled("che.serviceaccount.lockdown", contextBuilder().userId(userId).build());
 }

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Maintenance.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Maintenance.ceylon
@@ -1,55 +1,60 @@
+import ceylon.json {
+	JsonObject
+}
+
 import fr.minibilles.cli {
-    option
+	option
 }
 
 import io.fabric8.kubernetes.api.model {
-    PersistentVolumeClaimVolumeSourceBuilder,
-    VolumeBuilder,
-    VolumeMountBuilder
+	PersistentVolumeClaimVolumeSourceBuilder,
+	VolumeBuilder,
+	VolumeMountBuilder
 }
 import io.fabric8.kubernetes.client {
-    KubernetesClientException
+	KubernetesClientException
 }
 import io.fabric8.openshift.client {
-    DefaultOpenShiftClient,
-    OpenShiftClient
+	DefaultOpenShiftClient,
+	OpenShiftClient
 }
 import io.fabric8.tenant.che.migration.namespace {
-    ...
+	...
 }
 import io.fabric8.tenant.che.migration.workspaces {
-    log,
-    WorkspaceTool = Tool,
-    WorkspaceStatus=Status
+	log,
+	WorkspaceTool=Tool,
+	WorkspaceStatus=Status
 }
+import io.jsonwebtoken {
+	Jwts
+}
+
 import java.lang {
-    Thread {
-        sleep
-    }
+	Thread {
+		sleep
+	}
 }
 import java.util {
-    Arrays
-}
-import ceylon.json {
-    JsonObject
+	Arrays
 }
 
 Boolean() buildTimeout(Integer timeout) {
-    value end = system.milliseconds + timeout;
-    return () => system.milliseconds > end;
+	value end = system.milliseconds + timeout;
+	return () => system.milliseconds > end;
 }
 
 shared Maintenance withDefaultValues() => Maintenance(
-    environment.cheDestinationServer else "",
-    environment.osioToken else "",
-    false,
-    false,
-    environment.identityId else "",
-    environment.requestId else "",
-    environment.jobRequestId else "",
-    environment.osNamespace else "",
-    environment.osToken else "",
-    environment.debugLogs
+	environment.cheDestinationServer else "",
+	environment.osioToken else "",
+	false,
+	false,
+	environment.identityId else "",
+	environment.requestId else "",
+	environment.jobRequestId else "",
+	environment.osNamespace else "",
+	environment.osToken else "",
+	environment.debugLogs
 );
 
 "
@@ -62,268 +67,274 @@ shared Maintenance withDefaultValues() => Maintenance(
  cleanup the user Che tenant.
  "
 shared class Maintenance(
-
-        "
-         API Url of the Che server that contains workspaces to clean.
-
-         For example: `https://che.openshift.io/api`
-         "
-        option("che-server", 's')
-        shared String cheServer,
-
-        "
-         Keycloak (OSIO) token of the user that will be migrated
-         "
-        option("token", 't')
-        shared String keycloakToken,
-
-        "
-         Also stop and delete the existing workspaces before cleaning workspace directories
-         "
-        option("delete-all-workspaces", 'd')
-        shared Boolean deleteAllWorkspaces = false,
-
-        "
-         Only simulate the cleaning but don't apply it
-
-         Note that when compined with the `delete-all-workspaces`
-         option, the running workspaces will still be stopped,
-         but not deleted.
-         "
-        option("dry-run", 'z')
-        shared Boolean dryRun = false,
-
-        String identityId = "",
-        String requestId = "",
-        String jobRequestId = "",
-        String osNamespace = environment.osNamespace else "",
-        String osToken = environment.osToken else keycloakToken,
-        Boolean debugLogs = environment.debugLogs
-
-        ) extends NamespaceMigration(identityId, requestId, jobRequestId, osNamespace, osToken, debugLogs) {
-
-    name = Name.name;
-
-    function error(String message) {
-        log.error(message);
-        return Status(1, message);
-    }
-
-    shared actual Status migrate() {
-        value workspaceTool = WorkspaceTool(keycloakToken);
-        value listWorkspaces = curry(workspaceTool.listWorkspaces)(cheServer);
-        value getWorkspace = curry(workspaceTool.getWorkspace)(cheServer);
-        value getId = workspaceTool.getId;
-        value isStopped = workspaceTool.isStopped;
-        value stopWorkspace = curry(workspaceTool.stopWorkspace)(cheServer);
-        value deleteWorkspace = curry(workspaceTool.deleteWorkspace)(cheServer);
-
-        try(oc = DefaultOpenShiftClient(osConfig)) {
-            value namespace = osioCheNamespace(oc);
-
-            value lockConfigMap = "maintenance-lock";
-            value lockResources = oc.configMaps().inNamespace(namespace).withName(lockConfigMap);
-            if(lockResources.get() exists) {
-                log.info("A previous maintenance Job is already running. Waiting for it to finish...");
-            }
-
-            value timeoutMinutes = 10;
-            for(retry in 0:timeoutMinutes*60) {
-                if(! lockResources.get() exists) {
-                    try {
-                        if (lockResources.createNew().withNewMetadata().withName(lockConfigMap).endMetadata().done() exists) {
-                            break;
-                        }
-                    } catch(Exception e) {
-                        if (is KubernetesClientException e,
-                            exists reason = e.status.reason,
-                            reason == "AlreadyExists") {
-                            log.debug("Lock config map already exists. Waiting for it to be released");
-                        } else {
-                            log.warn("Exception when trying to create the lock config map", e);
-                        }
-                    }
-                }
-                sleep(1000);
-            } else {
-                return error("The maintenance lock is still owned, even after a ``timeoutMinutes`` minutes in namespace '`` namespace ``'
-                                 It might be necessary to remove the 'maintenance-lock' config map manually.");
-            }
-
-            try {
-                value workspaces = listWorkspaces();
-                if (is WorkspaceStatus workspaces) {
-                    return Status(1, workspaces.string);
-                }
-
-                {String*} workspaceIdsToKeep;
-                if(deleteAllWorkspaces) {
-                    for (wksp in workspaces) {
-                        value id = getId(wksp);
-                        if (! isStopped(wksp)) {
-                            if (!stopWorkspace(wksp)) {
-                                return error("The workspace `` id `` could not be stopped in namespace '`` namespace ``'");
-                            }
-                            value timeoutSeconds = 30;
-                            value stopTimedOut = buildTimeout(timeoutSeconds * 1000);
-                            value hasStopped =>
-                                    if (is JsonObject w = getWorkspace(id)) then isStopped(w) else false;
-
-                            while (! hasStopped) {
-                                if (stopTimedOut()) {
-                                    return error("The workspace `` id `` cannot be stopped, even after a `` timeoutSeconds `` seconds in namespace '`` namespace ``'");
-                                }
-                                sleep(1000);
-                            }
-                        }
-                        if (dryRun) {
-                            log.info(()=> "should delete workspace `` id `` (dry run)");
-                            continue;
-                        }
-                        if (!deleteWorkspace(wksp)) {
-                            return error("The workspace `` id `` could not be deleted in namespace '`` namespace ``'");
-                        }
-                    }
-
-                    workspaceIdsToKeep = {};
-                } else {
-                    workspaceIdsToKeep = workspaces.map(getId);
-                }
-
-                Status status;
-                value [code, stderr] = cleanWorkspaceFiles(oc, workspaceIdsToKeep);
-                if (exists code,
-                    code == 0) {
-                    log.info(() => "Workspace files correctly cleaned");
-                    status = Status(0, "");
-                } else {
-                    value detailedLog =
-                    if (exists code)
-                    then "Command failed with the following code: `` code `` and termination message: `` stderr else "" ``"
-                    else (stderr else "");
-
-                    String message = "Failure during cleaning of workspace files: `` detailedLog ``";
-                    log.error(" => `` message ``");
-
-                    status = Status(1, message, "");
-                }
-
-                if (status.code == 0) {
-                    log.info(status.message);
-                } else {
-                    log.error(status.message);
-                }
-                return status;
-            } catch(Exception e){
-                value message = "Unexpected exception while migrating namespace `` namespace ``";
-                log.error(message, e);
-                return Status(1, "`` message ``: `` e.message ``");
-            } finally {
-                lockResources.delete();
-            }
-        }
-    }
-
-    [Integer?,String?] cleanWorkspaceFiles(OpenShiftClient oc, {String*} workspacesIdsToKeep) {
-
-        value podName = "workspace-data-cleaning-`` if (requestId.empty) then system.milliseconds / 1000 else requestId.replace("-", "") ``";
-        value claimName = "claim-che-workspace";
-
-        if (! oc.persistentVolumeClaims().withName(claimName).get() exists) {
-            return [null, "PVC `` claimName `` doesn't exist !"];
-        }
-
-        value volumeName = "for-maintenance";
-
-        value volume =
-                VolumeBuilder()
-                    .withName(volumeName)
-                    .withPersistentVolumeClaim(
-                    PersistentVolumeClaimVolumeSourceBuilder()
-                        .withClaimName(claimName)
-                        .build())
-                    .build();
-
-        suppressWarnings("unusedDeclaration")
-        value pod = oc
-            .pods().createNew()
-            .withNewMetadata()
-            .withName(podName)
-            .endMetadata()
-            .withNewSpec()
-            .withRestartPolicy("Never")
-            .withVolumes(Arrays.asList(volume))
-            .addNewContainer()
-            .withName(podName)
-            .withImage("registry.access.redhat.com/rhel7-atomic")
-            .withImagePullPolicy("IfNotPresent")
-            .withVolumeMounts(Arrays.asList(*[
-            VolumeMountBuilder()
-                .withMountPath("/pvroot")
-                .withName(volumeName)
-                .build()
-        ]))
-            .withCommand(
-                "/bin/bash",
-                "-c",
-                " ".join{
-                    "eval 'set -e; for file in $(ls /pvroot); do",
-                    "case $file in",
-                    if (workspacesIdsToKeep.empty)
-                    then ""
-                    else "`` "|".join(workspacesIdsToKeep) ``) echo \"keeping $file\";;",
-                    "*)",
-                    if (dryRun)
-                    then """echo "should remove ${file} (dry run)";;"""
-                    else """echo "removing $file"; rm -Rf "/pvroot/$file";;""",
-                    "esac;",
-                    "done' 2> /dev/termination-log"
-                }
-            )
-            .endContainer()
-            .endSpec()
-            .done();
-
-        function terminated() {
-            if (exists pod = oc.pods()
-                .withName(podName)
-                .get(),
-                exists containerStatuses = pod.status?.containerStatuses,
-                containerStatuses.size() > 0,
-                exists status = containerStatuses.get(0),
-                exists terminated = status.state?.terminated) {
-                return terminated;
-            }
-            return null;
-        }
-
-        value commandTimedOut = buildTimeout(60000);
-        variable value status = terminated();
-
-        while(! status exists) {
-            if (commandTimedOut()) {
-                break;
-            }
-            sleep(1000);
-            status = terminated();
-        }
-
-        if (exists terminationStatus = status) {
-            return [
-                terminationStatus.exitCode.intValue(),
-                terminationStatus.message of String?
-            ];
-        } else {
-            if (exists pendingPod = oc.pods()
-                .withName(podName)
-                .get(),
-                exists phase = pendingPod.status?.phase,
-                phase == "Pending") {
-                    oc.pods().withName(podName).delete();
-            }
-            
-            return  [null, "Timeout while waiting for container creation or command execution"];
-        }
-    }
+	"
+	 API Url of the Che server that contains workspaces to clean.
+	
+	 For example: `https://che.openshift.io/api`
+	 "
+	option ("che-server", 's')
+	shared String cheServer,
+	"
+	 Keycloak (OSIO) token of the user that will be migrated
+	 "
+	option ("token", 't')
+	shared String keycloakToken,
+	"
+	 Also stop and delete the existing workspaces before cleaning workspace directories
+	 "
+	option ("delete-all-workspaces", 'd')
+	shared Boolean deleteAllWorkspaces = false,
+	"
+	 Only simulate the cleaning but don't apply it
+	
+	 Note that when compined with the `delete-all-workspaces`
+	 option, the running workspaces will still be stopped,
+	 but not deleted.
+	 "
+	option ("dry-run", 'z')
+	shared Boolean dryRun = false,
+	String identityId = "",
+	String requestId = "",
+	String jobRequestId = "",
+	String osNamespace = environment.osNamespace else "",
+	String osToken = environment.osToken else keycloakToken,
+	Boolean debugLogs = environment.debugLogs) extends NamespaceMigration(identityId, requestId, jobRequestId, osNamespace, osToken, debugLogs, (config) {
+		
+		value userId =
+			if (!identityId.empty)
+			then identityId
+			else Jwts.parser().parseClaimsJwt(keycloakToken[0..(keycloakToken.lastInclusion(".") else 0)]).body.subject;
+		
+		if (exists serviceAccountToken = cheServiceAccountTokenManager.token,
+			cheServiceAccountTokenManager.useCheServiceAccountToken(userId)) {
+			
+			log.debug(() => "Using Che SA token for ``userId ``");
+			config.requestConfig.impersonateUsername = userId;
+			config.oauthToken = serviceAccountToken;
+		}
+	}) {
+	
+	name = Name.name;
+	
+	function error(String message) {
+		log.error(message);
+		return Status(1, message);
+	}
+	
+	shared actual Status migrate() {
+		value workspaceTool = WorkspaceTool(keycloakToken);
+		value listWorkspaces = curry(workspaceTool.listWorkspaces)(cheServer);
+		value getWorkspace = curry(workspaceTool.getWorkspace)(cheServer);
+		value getId = workspaceTool.getId;
+		value isStopped = workspaceTool.isStopped;
+		value stopWorkspace = curry(workspaceTool.stopWorkspace)(cheServer);
+		value deleteWorkspace = curry(workspaceTool.deleteWorkspace)(cheServer);
+		
+		try (oc = DefaultOpenShiftClient(osConfig)) {
+			value namespace = osioCheNamespace(oc);
+			
+			value lockConfigMap = "maintenance-lock";
+			value lockResources = oc.configMaps().inNamespace(namespace).withName(lockConfigMap);
+			if (lockResources.get() exists) {
+				log.info("A previous maintenance Job is already running. Waiting for it to finish...");
+			}
+			
+			value timeoutMinutes = 10;
+			for (retry in 0 : timeoutMinutes*60) {
+				if (!lockResources.get() exists) {
+					try {
+						if (lockResources.createNew().withNewMetadata().withName(lockConfigMap).endMetadata().done() exists) {
+							break;
+						}
+					} catch (Exception e) {
+						if (is KubernetesClientException e,
+							exists reason = e.status.reason,
+							reason == "AlreadyExists") {
+							log.debug("Lock config map already exists. Waiting for it to be released");
+						} else {
+							log.warn("Exception when trying to create the lock config map", e);
+						}
+					}
+				}
+				sleep(1000);
+			} else {
+				return error("The maintenance lock is still owned, even after a ``timeoutMinutes`` minutes in namespace '``namespace``'
+				                 It might be necessary to remove the 'maintenance-lock' config map manually.");
+			}
+			
+			try {
+				value workspaces = listWorkspaces();
+				if (is WorkspaceStatus workspaces) {
+					return Status(1, workspaces.string);
+				}
+				
+				{String*} workspaceIdsToKeep;
+				if (deleteAllWorkspaces) {
+					for (wksp in workspaces) {
+						value id = getId(wksp);
+						if (!isStopped(wksp)) {
+							if (!stopWorkspace(wksp)) {
+								return error("The workspace ``id`` could not be stopped in namespace '``namespace``'");
+							}
+							value timeoutSeconds = 30;
+							value stopTimedOut = buildTimeout(timeoutSeconds * 1000);
+							value hasStopped =>
+								if (is JsonObject w = getWorkspace(id)) then isStopped(w) else false;
+							
+							while (!hasStopped) {
+								if (stopTimedOut()) {
+									return error("The workspace ``id`` cannot be stopped, even after a ``timeoutSeconds`` seconds in namespace '``namespace``'");
+								}
+								sleep(1000);
+							}
+						}
+						if (dryRun) {
+							log.info(() => "should delete workspace ``id`` (dry run)");
+							continue;
+						}
+						if (!deleteWorkspace(wksp)) {
+							return error("The workspace ``id`` could not be deleted in namespace '``namespace``'");
+						}
+					}
+					
+					workspaceIdsToKeep = {};
+				} else {
+					workspaceIdsToKeep = workspaces.map(getId);
+				}
+				
+				Status status;
+				value [code, stderr] = cleanWorkspaceFiles(oc, workspaceIdsToKeep);
+				if (exists code,
+					code == 0) {
+					log.info(() => "Workspace files correctly cleaned");
+					status = Status(0, "");
+				} else {
+					value detailedLog =
+						if (exists code)
+						then "Command failed with the following code: ``code`` and termination message: `` stderr else "" ``"
+						else (stderr else "");
+					
+					String message = "Failure during cleaning of workspace files: ``detailedLog``";
+					log.error(" => ``message``");
+					
+					status = Status(1, message, "");
+				}
+				
+				if (status.code == 0) {
+					log.info(status.message);
+				} else {
+					log.error(status.message);
+				}
+				return status;
+			} catch (Exception e) {
+				value message = "Unexpected exception while migrating namespace ``namespace``";
+				log.error(message, e);
+				return Status(1, "``message``: ``e.message``");
+			} finally {
+				lockResources.delete();
+			}
+		}
+	}
+	
+	[Integer?, String?] cleanWorkspaceFiles(OpenShiftClient oc, {String*} workspacesIdsToKeep) {
+		
+		value podName = "workspace-data-cleaning-`` if (requestId.empty) then system.milliseconds / 1000 else requestId.replace("-", "") ``";
+		value claimName = "claim-che-workspace";
+		
+		if (!oc.persistentVolumeClaims().withName(claimName).get() exists) {
+			return [null, "PVC ``claimName`` doesn't exist !"];
+		}
+		
+		value volumeName = "for-maintenance";
+		
+		value volume =
+			VolumeBuilder()
+				.withName(volumeName)
+				.withPersistentVolumeClaim(
+				PersistentVolumeClaimVolumeSourceBuilder()
+					.withClaimName(claimName)
+					.build())
+				.build();
+		
+		suppressWarnings ("unusedDeclaration")
+		value pod = oc
+			.pods().createNew()
+			.withNewMetadata()
+			.withName(podName)
+			.endMetadata()
+			.withNewSpec()
+			.withRestartPolicy("Never")
+			.withVolumes(Arrays.asList(volume))
+			.addNewContainer()
+			.withName(podName)
+			.withImage("registry.access.redhat.com/rhel7-atomic")
+			.withImagePullPolicy("IfNotPresent")
+			.withVolumeMounts(Arrays.asList(*[
+					VolumeMountBuilder()
+						.withMountPath("/pvroot")
+						.withName(volumeName)
+						.build()
+				]))
+			.withCommand(
+			"/bin/bash",
+			"-c",
+			" ".join {
+				"eval 'set -e; for file in $(ls /pvroot); do",
+				"case $file in",
+				if (workspacesIdsToKeep.empty)
+				then ""
+				else "``"|".join(workspacesIdsToKeep)``) echo \"keeping $file\";;",
+				"*)",
+				if (dryRun)
+				then """echo "should remove ${file} (dry run)";;"""
+				else """echo "removing $file"; rm -Rf "/pvroot/$file";;""",
+				"esac;",
+				"done' 2> /dev/termination-log"
+			}
+		)
+			.endContainer()
+			.endSpec()
+			.done();
+		
+		function terminated() {
+			if (exists pod = oc.pods()
+					.withName(podName)
+					.get(),
+				exists containerStatuses = pod.status?.containerStatuses,
+				containerStatuses.size() > 0,
+				exists status = containerStatuses.get(0),
+				exists terminated = status.state?.terminated) {
+				return terminated;
+			}
+			return null;
+		}
+		
+		value commandTimedOut = buildTimeout(60000);
+		variable value status = terminated();
+		
+		while (!status exists) {
+			if (commandTimedOut()) {
+				break;
+			}
+			sleep(1000);
+			status = terminated();
+		}
+		
+		if (exists terminationStatus = status) {
+			return [
+				terminationStatus.exitCode.intValue(),
+				terminationStatus.message of String?
+			];
+		} else {
+			if (exists pendingPod = oc.pods()
+					.withName(podName)
+					.get(),
+				exists phase = pendingPod.status?.phase,
+				phase == "Pending") {
+				oc.pods().withName(podName).delete();
+			}
+			
+			return [null, "Timeout while waiting for container creation or command execution"];
+		}
+	}
 }
-

--- a/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Maintenance.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/cleanWorkspaces/Maintenance.ceylon
@@ -1,60 +1,60 @@
 import ceylon.json {
-	JsonObject
+    JsonObject
 }
 
 import fr.minibilles.cli {
-	option
+    option
 }
 
 import io.fabric8.kubernetes.api.model {
-	PersistentVolumeClaimVolumeSourceBuilder,
-	VolumeBuilder,
-	VolumeMountBuilder
+    PersistentVolumeClaimVolumeSourceBuilder,
+    VolumeBuilder,
+    VolumeMountBuilder
 }
 import io.fabric8.kubernetes.client {
-	KubernetesClientException
+    KubernetesClientException
 }
 import io.fabric8.openshift.client {
-	DefaultOpenShiftClient,
-	OpenShiftClient
+    DefaultOpenShiftClient,
+    OpenShiftClient
 }
 import io.fabric8.tenant.che.migration.namespace {
-	...
+    ...
 }
 import io.fabric8.tenant.che.migration.workspaces {
-	log,
-	WorkspaceTool=Tool,
-	WorkspaceStatus=Status
+    log,
+    WorkspaceTool=Tool,
+    WorkspaceStatus=Status
 }
 import io.jsonwebtoken {
-	Jwts
+    Jwts
 }
 
 import java.lang {
-	Thread {
-		sleep
-	}
+    Thread {
+        sleep
+    }
 }
 import java.util {
-	Arrays
+    Arrays
 }
 
 Boolean() buildTimeout(Integer timeout) {
-	value end = system.milliseconds + timeout;
-	return () => system.milliseconds > end;
+    value end = system.milliseconds + timeout;
+    return () => system.milliseconds > end;
 }
 
 shared Maintenance withDefaultValues() => Maintenance(
-	environment.cheDestinationServer else "",
-	environment.osioToken else "",
-	false,
-	false,
-	environment.identityId else "",
-	environment.requestId else "",
-	environment.jobRequestId else "",
-	environment.osNamespace else "",
-	environment.osToken else "",
-	environment.debugLogs
+    environment.cheDestinationServer else "",
+    environment.osioToken else "",
+    false,
+    false,
+    environment.identityId else "",
+    environment.requestId else "",
+    environment.jobRequestId else "",
+    environment.osNamespace else "",
+    environment.osToken else "",
+    environment.debugLogs
 );
 
 "
@@ -67,274 +67,274 @@ shared Maintenance withDefaultValues() => Maintenance(
  cleanup the user Che tenant.
  "
 shared class Maintenance(
-	"
-	 API Url of the Che server that contains workspaces to clean.
-	
-	 For example: `https://che.openshift.io/api`
-	 "
-	option ("che-server", 's')
-	shared String cheServer,
-	"
-	 Keycloak (OSIO) token of the user that will be migrated
-	 "
-	option ("token", 't')
-	shared String keycloakToken,
-	"
-	 Also stop and delete the existing workspaces before cleaning workspace directories
-	 "
-	option ("delete-all-workspaces", 'd')
-	shared Boolean deleteAllWorkspaces = false,
-	"
-	 Only simulate the cleaning but don't apply it
-	
-	 Note that when compined with the `delete-all-workspaces`
-	 option, the running workspaces will still be stopped,
-	 but not deleted.
-	 "
-	option ("dry-run", 'z')
-	shared Boolean dryRun = false,
-	String identityId = "",
-	String requestId = "",
-	String jobRequestId = "",
-	String osNamespace = environment.osNamespace else "",
-	String osToken = environment.osToken else keycloakToken,
-	Boolean debugLogs = environment.debugLogs) extends NamespaceMigration(identityId, requestId, jobRequestId, osNamespace, osToken, debugLogs, (config) {
-		
-		value userId =
-			if (!identityId.empty)
-			then identityId
-			else Jwts.parser().parseClaimsJwt(keycloakToken[0..(keycloakToken.lastInclusion(".") else 0)]).body.subject;
-		
-		if (exists serviceAccountToken = cheServiceAccountTokenManager.token,
-			cheServiceAccountTokenManager.useCheServiceAccountToken(userId)) {
-			
-			log.debug(() => "Using Che SA token for ``userId ``");
-			config.requestConfig.impersonateUsername = userId;
-			config.oauthToken = serviceAccountToken;
-		}
-	}) {
-	
-	name = Name.name;
-	
-	function error(String message) {
-		log.error(message);
-		return Status(1, message);
-	}
-	
-	shared actual Status migrate() {
-		value workspaceTool = WorkspaceTool(keycloakToken);
-		value listWorkspaces = curry(workspaceTool.listWorkspaces)(cheServer);
-		value getWorkspace = curry(workspaceTool.getWorkspace)(cheServer);
-		value getId = workspaceTool.getId;
-		value isStopped = workspaceTool.isStopped;
-		value stopWorkspace = curry(workspaceTool.stopWorkspace)(cheServer);
-		value deleteWorkspace = curry(workspaceTool.deleteWorkspace)(cheServer);
-		
-		try (oc = DefaultOpenShiftClient(osConfig)) {
-			value namespace = osioCheNamespace(oc);
-			
-			value lockConfigMap = "maintenance-lock";
-			value lockResources = oc.configMaps().inNamespace(namespace).withName(lockConfigMap);
-			if (lockResources.get() exists) {
-				log.info("A previous maintenance Job is already running. Waiting for it to finish...");
-			}
-			
-			value timeoutMinutes = 10;
-			for (retry in 0 : timeoutMinutes*60) {
-				if (!lockResources.get() exists) {
-					try {
-						if (lockResources.createNew().withNewMetadata().withName(lockConfigMap).endMetadata().done() exists) {
-							break;
-						}
-					} catch (Exception e) {
-						if (is KubernetesClientException e,
-							exists reason = e.status.reason,
-							reason == "AlreadyExists") {
-							log.debug("Lock config map already exists. Waiting for it to be released");
-						} else {
-							log.warn("Exception when trying to create the lock config map", e);
-						}
-					}
-				}
-				sleep(1000);
-			} else {
-				return error("The maintenance lock is still owned, even after a ``timeoutMinutes`` minutes in namespace '``namespace``'
-				                 It might be necessary to remove the 'maintenance-lock' config map manually.");
-			}
-			
-			try {
-				value workspaces = listWorkspaces();
-				if (is WorkspaceStatus workspaces) {
-					return Status(1, workspaces.string);
-				}
-				
-				{String*} workspaceIdsToKeep;
-				if (deleteAllWorkspaces) {
-					for (wksp in workspaces) {
-						value id = getId(wksp);
-						if (!isStopped(wksp)) {
-							if (!stopWorkspace(wksp)) {
-								return error("The workspace ``id`` could not be stopped in namespace '``namespace``'");
-							}
-							value timeoutSeconds = 30;
-							value stopTimedOut = buildTimeout(timeoutSeconds * 1000);
-							value hasStopped =>
-								if (is JsonObject w = getWorkspace(id)) then isStopped(w) else false;
-							
-							while (!hasStopped) {
-								if (stopTimedOut()) {
-									return error("The workspace ``id`` cannot be stopped, even after a ``timeoutSeconds`` seconds in namespace '``namespace``'");
-								}
-								sleep(1000);
-							}
-						}
-						if (dryRun) {
-							log.info(() => "should delete workspace ``id`` (dry run)");
-							continue;
-						}
-						if (!deleteWorkspace(wksp)) {
-							return error("The workspace ``id`` could not be deleted in namespace '``namespace``'");
-						}
-					}
-					
-					workspaceIdsToKeep = {};
-				} else {
-					workspaceIdsToKeep = workspaces.map(getId);
-				}
-				
-				Status status;
-				value [code, stderr] = cleanWorkspaceFiles(oc, workspaceIdsToKeep);
-				if (exists code,
-					code == 0) {
-					log.info(() => "Workspace files correctly cleaned");
-					status = Status(0, "");
-				} else {
-					value detailedLog =
-						if (exists code)
-						then "Command failed with the following code: ``code`` and termination message: `` stderr else "" ``"
-						else (stderr else "");
-					
-					String message = "Failure during cleaning of workspace files: ``detailedLog``";
-					log.error(" => ``message``");
-					
-					status = Status(1, message, "");
-				}
-				
-				if (status.code == 0) {
-					log.info(status.message);
-				} else {
-					log.error(status.message);
-				}
-				return status;
-			} catch (Exception e) {
-				value message = "Unexpected exception while migrating namespace ``namespace``";
-				log.error(message, e);
-				return Status(1, "``message``: ``e.message``");
-			} finally {
-				lockResources.delete();
-			}
-		}
-	}
-	
-	[Integer?, String?] cleanWorkspaceFiles(OpenShiftClient oc, {String*} workspacesIdsToKeep) {
-		
-		value podName = "workspace-data-cleaning-`` if (requestId.empty) then system.milliseconds / 1000 else requestId.replace("-", "") ``";
-		value claimName = "claim-che-workspace";
-		
-		if (!oc.persistentVolumeClaims().withName(claimName).get() exists) {
-			return [null, "PVC ``claimName`` doesn't exist !"];
-		}
-		
-		value volumeName = "for-maintenance";
-		
-		value volume =
-			VolumeBuilder()
-				.withName(volumeName)
-				.withPersistentVolumeClaim(
-				PersistentVolumeClaimVolumeSourceBuilder()
-					.withClaimName(claimName)
-					.build())
-				.build();
-		
-		suppressWarnings ("unusedDeclaration")
-		value pod = oc
-			.pods().createNew()
-			.withNewMetadata()
-			.withName(podName)
-			.endMetadata()
-			.withNewSpec()
-			.withRestartPolicy("Never")
-			.withVolumes(Arrays.asList(volume))
-			.addNewContainer()
-			.withName(podName)
-			.withImage("registry.access.redhat.com/rhel7-atomic")
-			.withImagePullPolicy("IfNotPresent")
-			.withVolumeMounts(Arrays.asList(*[
-					VolumeMountBuilder()
-						.withMountPath("/pvroot")
-						.withName(volumeName)
-						.build()
-				]))
-			.withCommand(
-			"/bin/bash",
-			"-c",
-			" ".join {
-				"eval 'set -e; for file in $(ls /pvroot); do",
-				"case $file in",
-				if (workspacesIdsToKeep.empty)
-				then ""
-				else "``"|".join(workspacesIdsToKeep)``) echo \"keeping $file\";;",
-				"*)",
-				if (dryRun)
-				then """echo "should remove ${file} (dry run)";;"""
-				else """echo "removing $file"; rm -Rf "/pvroot/$file";;""",
-				"esac;",
-				"done' 2> /dev/termination-log"
-			}
-		)
-			.endContainer()
-			.endSpec()
-			.done();
-		
-		function terminated() {
-			if (exists pod = oc.pods()
-					.withName(podName)
-					.get(),
-				exists containerStatuses = pod.status?.containerStatuses,
-				containerStatuses.size() > 0,
-				exists status = containerStatuses.get(0),
-				exists terminated = status.state?.terminated) {
-				return terminated;
-			}
-			return null;
-		}
-		
-		value commandTimedOut = buildTimeout(60000);
-		variable value status = terminated();
-		
-		while (!status exists) {
-			if (commandTimedOut()) {
-				break;
-			}
-			sleep(1000);
-			status = terminated();
-		}
-		
-		if (exists terminationStatus = status) {
-			return [
-				terminationStatus.exitCode.intValue(),
-				terminationStatus.message of String?
-			];
-		} else {
-			if (exists pendingPod = oc.pods()
-					.withName(podName)
-					.get(),
-				exists phase = pendingPod.status?.phase,
-				phase == "Pending") {
-				oc.pods().withName(podName).delete();
-			}
-			
-			return [null, "Timeout while waiting for container creation or command execution"];
-		}
-	}
+    "
+        API Url of the Che server that contains workspaces to clean.
+       
+        For example: `https://che.openshift.io/api`
+        "
+    option ("che-server", 's')
+    shared String cheServer,
+    "
+        Keycloak (OSIO) token of the user that will be migrated
+        "
+    option ("token", 't')
+    shared String keycloakToken,
+    "
+        Also stop and delete the existing workspaces before cleaning workspace directories
+        "
+    option ("delete-all-workspaces", 'd')
+    shared Boolean deleteAllWorkspaces = false,
+    "
+        Only simulate the cleaning but don't apply it
+       
+        Note that when compined with the `delete-all-workspaces`
+        option, the running workspaces will still be stopped,
+        but not deleted.
+        "
+    option ("dry-run", 'z')
+    shared Boolean dryRun = false,
+    String identityId = "",
+    String requestId = "",
+    String jobRequestId = "",
+    String osNamespace = environment.osNamespace else "",
+    String osToken = environment.osToken else keycloakToken,
+    Boolean debugLogs = environment.debugLogs) extends NamespaceMigration(identityId, requestId, jobRequestId, osNamespace, osToken, debugLogs, (config) {
+        
+        value userId =
+            if (!identityId.empty)
+            then identityId
+            else Jwts.parser().parseClaimsJwt(keycloakToken[0 .. (keycloakToken.lastInclusion(".") else 0)]).body.subject;
+        
+        if (exists serviceAccountToken = cheServiceAccountTokenManager.token,
+            cheServiceAccountTokenManager.useCheServiceAccountToken(userId)) {
+            
+            log.debug(() => "Using Che SA token for ``userId``");
+            config.requestConfig.impersonateUsername = userId;
+            config.oauthToken = serviceAccountToken;
+        }
+    }) {
+    
+    name = Name.name;
+    
+    function error(String message) {
+        log.error(message);
+        return Status(1, message);
+    }
+    
+    shared actual Status migrate() {
+        value workspaceTool = WorkspaceTool(keycloakToken);
+        value listWorkspaces = curry(workspaceTool.listWorkspaces)(cheServer);
+        value getWorkspace = curry(workspaceTool.getWorkspace)(cheServer);
+        value getId = workspaceTool.getId;
+        value isStopped = workspaceTool.isStopped;
+        value stopWorkspace = curry(workspaceTool.stopWorkspace)(cheServer);
+        value deleteWorkspace = curry(workspaceTool.deleteWorkspace)(cheServer);
+        
+        try (oc = DefaultOpenShiftClient(osConfig)) {
+            value namespace = osioCheNamespace(oc);
+            
+            value lockConfigMap = "maintenance-lock";
+            value lockResources = oc.configMaps().inNamespace(namespace).withName(lockConfigMap);
+            if (lockResources.get() exists) {
+                log.info("A previous maintenance Job is already running. Waiting for it to finish...");
+            }
+            
+            value timeoutMinutes = 10;
+            for (retry in 0 : timeoutMinutes*60) {
+                if (!lockResources.get() exists) {
+                    try {
+                        if (lockResources.createNew().withNewMetadata().withName(lockConfigMap).endMetadata().done() exists) {
+                            break;
+                        }
+                    } catch (Exception e) {
+                        if (is KubernetesClientException e,
+                            exists reason = e.status.reason,
+                            reason == "AlreadyExists") {
+                            log.debug("Lock config map already exists. Waiting for it to be released");
+                        } else {
+                            log.warn("Exception when trying to create the lock config map", e);
+                        }
+                    }
+                }
+                sleep(1000);
+            } else {
+                return error("The maintenance lock is still owned, even after a ``timeoutMinutes`` minutes in namespace '``namespace``'
+                                             It might be necessary to remove the 'maintenance-lock' config map manually.");
+            }
+            
+            try {
+                value workspaces = listWorkspaces();
+                if (is WorkspaceStatus workspaces) {
+                    return Status(1, workspaces.string);
+                }
+                
+                {String*} workspaceIdsToKeep;
+                if (deleteAllWorkspaces) {
+                    for (wksp in workspaces) {
+                        value id = getId(wksp);
+                        if (!isStopped(wksp)) {
+                            if (!stopWorkspace(wksp)) {
+                                return error("The workspace ``id`` could not be stopped in namespace '``namespace``'");
+                            }
+                            value timeoutSeconds = 30;
+                            value stopTimedOut = buildTimeout(timeoutSeconds * 1000);
+                            value hasStopped =>
+                                if (is JsonObject w = getWorkspace(id)) then isStopped(w) else false;
+                            
+                            while (!hasStopped) {
+                                if (stopTimedOut()) {
+                                    return error("The workspace ``id`` cannot be stopped, even after a ``timeoutSeconds`` seconds in namespace '``namespace``'");
+                                }
+                                sleep(1000);
+                            }
+                        }
+                        if (dryRun) {
+                            log.info(() => "should delete workspace ``id`` (dry run)");
+                            continue;
+                        }
+                        if (!deleteWorkspace(wksp)) {
+                            return error("The workspace ``id`` could not be deleted in namespace '``namespace``'");
+                        }
+                    }
+                    
+                    workspaceIdsToKeep = {};
+                } else {
+                    workspaceIdsToKeep = workspaces.map(getId);
+                }
+                
+                Status status;
+                value [code, stderr] = cleanWorkspaceFiles(oc, workspaceIdsToKeep);
+                if (exists code,
+                    code == 0) {
+                    log.info(() => "Workspace files correctly cleaned");
+                    status = Status(0, "");
+                } else {
+                    value detailedLog =
+                        if (exists code)
+                        then "Command failed with the following code: ``code`` and termination message: `` stderr else "" ``"
+                        else (stderr else "");
+                    
+                    String message = "Failure during cleaning of workspace files: ``detailedLog``";
+                    log.error(" => ``message``");
+                    
+                    status = Status(1, message, "");
+                }
+                
+                if (status.code == 0) {
+                    log.info(status.message);
+                } else {
+                    log.error(status.message);
+                }
+                return status;
+            } catch (Exception e) {
+                value message = "Unexpected exception while migrating namespace ``namespace``";
+                log.error(message, e);
+                return Status(1, "``message``: ``e.message``");
+            } finally {
+                lockResources.delete();
+            }
+        }
+    }
+    
+    [Integer?, String?] cleanWorkspaceFiles(OpenShiftClient oc, {String*} workspacesIdsToKeep) {
+        
+        value podName = "workspace-data-cleaning-`` if (requestId.empty) then system.milliseconds / 1000 else requestId.replace("-", "") ``";
+        value claimName = "claim-che-workspace";
+        
+        if (!oc.persistentVolumeClaims().withName(claimName).get() exists) {
+            return [null, "PVC ``claimName`` doesn't exist !"];
+        }
+        
+        value volumeName = "for-maintenance";
+        
+        value volume =
+            VolumeBuilder()
+                .withName(volumeName)
+                .withPersistentVolumeClaim(
+                PersistentVolumeClaimVolumeSourceBuilder()
+                    .withClaimName(claimName)
+                    .build())
+                .build();
+        
+        suppressWarnings ("unusedDeclaration")
+        value pod = oc
+            .pods().createNew()
+            .withNewMetadata()
+            .withName(podName)
+            .endMetadata()
+            .withNewSpec()
+            .withRestartPolicy("Never")
+            .withVolumes(Arrays.asList(volume))
+            .addNewContainer()
+            .withName(podName)
+            .withImage("registry.access.redhat.com/rhel7-atomic")
+            .withImagePullPolicy("IfNotPresent")
+            .withVolumeMounts(Arrays.asList(*[
+                    VolumeMountBuilder()
+                        .withMountPath("/pvroot")
+                        .withName(volumeName)
+                        .build()
+                ]))
+            .withCommand(
+            "/bin/bash",
+            "-c",
+            " ".join {
+                "eval 'set -e; for file in $(ls /pvroot); do",
+                "case $file in",
+                if (workspacesIdsToKeep.empty)
+                then ""
+                else "``"|".join(workspacesIdsToKeep)``) echo \"keeping $file\";;",
+                "*)",
+                if (dryRun)
+                then """echo "should remove ${file} (dry run)";;"""
+                else """echo "removing $file"; rm -Rf "/pvroot/$file";;""",
+                "esac;",
+                "done' 2> /dev/termination-log"
+            }
+        )
+            .endContainer()
+            .endSpec()
+            .done();
+        
+        function terminated() {
+            if (exists pod = oc.pods()
+                    .withName(podName)
+                    .get(),
+                exists containerStatuses = pod.status?.containerStatuses,
+                containerStatuses.size() > 0,
+                exists status = containerStatuses.get(0),
+                exists terminated = status.state?.terminated) {
+                return terminated;
+            }
+            return null;
+        }
+        
+        value commandTimedOut = buildTimeout(60000);
+        variable value status = terminated();
+        
+        while (!status exists) {
+            if (commandTimedOut()) {
+                break;
+            }
+            sleep(1000);
+            status = terminated();
+        }
+        
+        if (exists terminationStatus = status) {
+            return [
+                terminationStatus.exitCode.intValue(),
+                terminationStatus.message of String?
+            ];
+        } else {
+            if (exists pendingPod = oc.pods()
+                    .withName(podName)
+                    .get(),
+                exists phase = pendingPod.status?.phase,
+                phase == "Pending") {
+                oc.pods().withName(podName).delete();
+            }
+            
+            return [null, "Timeout while waiting for container creation or command execution"];
+        }
+    }
 }

--- a/source/io/fabric8/tenant/che/migration/namespace/environment.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/environment.ceylon
@@ -19,6 +19,9 @@ shared object environment {
     shared String? multiTenantCheServer = get("CHE_MULTITENANT_SERVER");
     shared String? cleanupSingleTenant = get("CLEANUP_SINGLE_TENANT");
     shared String? cheDestinationServer = get("CHE_DESTINATION_SERVER");
+    shared String? serviceAccountId = get("SERVICE_ACCOUNT_ID");
+    shared String? serviceAccountSecret = get("SERVICE_ACCOUNT_SECRET");
+    shared String? authApiUrl = get("AUTH_API_URL");
 }
 
 

--- a/source/io/fabric8/tenant/che/migration/namespace/module.ceylon
+++ b/source/io/fabric8/tenant/che/migration/namespace/module.ceylon
@@ -2,10 +2,12 @@ native("jvm")
 module io.fabric8.tenant.che.migration.namespace "1.0.0" {
     shared optional import maven:"javax.ws.rs:javax.ws.rs-api" "2.1";
     shared import io.fabric8.tenant.che.migration.workspaces "1.0.0";
-    shared import maven:io.fabric8:"openshift-client" "2.6.3";
+    shared import maven:io.fabric8:"openshift-client" "3.1.12";
     shared import ceylon.interop.java "1.3.3";
     shared import fr.minibilles.cli "0.3.0";
     shared import ceylon.logging "1.3.3";
     shared import java.base "8";
     import maven:"org.slf4j:slf4j-nop" "1.7.13";
+    import maven:"no.finn.unleash:unleash-client-java" "3.0.0";
+    import maven:"io.jsonwebtoken:jjwt" "0.9.0";
 }

--- a/source/io/fabric8/tenant/che/migration/workspaces/module.ceylon
+++ b/source/io/fabric8/tenant/che/migration/workspaces/module.ceylon
@@ -3,7 +3,7 @@ module io.fabric8.tenant.che.migration.workspaces "1.0.0" {
     shared optional import maven:"javax.ws.rs:javax.ws.rs-api" "2.1";
     shared import ceylon.time "1.3.3";
     shared import ceylon.file "1.3.3";
-    shared import maven:"com.squareup.okhttp3:okhttp" "3.8.1";
+    shared import maven:"com.squareup.okhttp3:okhttp" "3.9.1";
     shared import ceylon.json "1.3.3";
     shared import fr.minibilles.cli "0.3.0";
     shared import ceylon.logging "1.3.3";


### PR DESCRIPTION
## What this PR does

Now that the new restriction on the user OSIO Che namespace access is enabled in oso-proxy and `rh-che`, the  `che-tenant-maintainer` application will no  longer have access to the user Che namespace based on its OSIO token. We should adapt it to implement the same logic as the one used in `rh-che` to have access to the user Che namespace.

## What issue this PR fixes

https://github.com/redhat-developer/rh-che/issues/691

## How was this PR tested

Tested locally against my prod-preview account after enable the access restriction toggle.  
