### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/jboss-jdk-8:latest
+FROM quay.io/openshiftio/rhel-base-jboss-jdk-8:latest
 
 ENV JAVA_HOME /etc/alternatives/jre
 ENV CHE_TENANT_MAINTAINER_HOME /opt/che-tenant-maintainer

--- a/buildAndPushToDocker.sh
+++ b/buildAndPushToDocker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-REGISTRY=${REGISTRY:-"docker.io"}
+REGISTRY=${REGISTRY:-"quay.io"}
 NAMESPACE=${NAMESPACE:-"dfestal"}
 ADD_REST_ENDPOINTS=${ADD_REST_ENDPOINTS:-false}
 DOCKERFILE=${DOCKERFILE:-"Dockerfile"}
@@ -19,9 +19,11 @@ else
   docker build -t f8tenant-che-migration-deploy -f ${DOCKERFILE} .
 fi
 
-
-if [ "$TAG" != "" ];
-then
-  tag_push ${REGISTRY}/${NAMESPACE}/fabric8-tenant-che-migration:$TAG
+if [[ "$TARGET" == "rhel" ]]; then
+    IMAGE=${REGISTRY}/rhel-${NAMESPACE}-fabric8-tenant-che-migration
+else
+    IMAGE=${REGISTRY}/${NAMESPACE}-fabric8-tenant-che-migration
 fi
-tag_push ${REGISTRY}/${NAMESPACE}/fabric8-tenant-che-migration:latest
+
+[ -n "$TAG" ] && tag_push ${IMAGE}:${TAG}
+tag_push ${IMAGE}:latest

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -6,14 +6,15 @@ set -x
 # Exit on error
 set -e
 
+REGISTRY=${REGISTRY:-quay.io}
+
 # TARGET variable gives ability to switch context for building rhel based images, default is "centos"
 # If CI slave is configured with TARGET="rhel" RHEL based images should be generated then.
 TARGET=${TARGET:-"centos"}
+
 if [ $TARGET == "rhel" ]; then
   DOCKERFILE="Dockerfile.rhel"
-  REGISTRY=${DOCKER_REGISTRY:-"push.registry.devshift.net/osio-prod"}
 else
-  REGISTRY=${REGISTRY:-"push.registry.devshift.net"}
   DOCKERFILE="Dockerfile"
 fi
 NAMESPACE=${NAMESPACE:-"fabric8-services"}
@@ -21,12 +22,19 @@ NAMESPACE=${NAMESPACE:-"fabric8-services"}
 # Source environment variables of the jenkins slave
 # that might interest this worker.
 function load_jenkins_vars() {
-  if [ -e "jenkins-env" ]; then
-    cat jenkins-env \
-      | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-      | sed 's/^/export /g' \
-      > ~/.jenkins-env
-    source ~/.jenkins-env
+  if [ -e "jenkins-env.json" ]; then
+    eval "$(./env-toolkit load -f jenkins-env.json \
+            DEVSHIFT_TAG_LEN \
+            QUAY_USERNAME \
+            QUAY_PASSWORD \
+            JENKINS_URL \
+            GIT_BRANCH \
+            GIT_COMMIT \
+            BUILD_NUMBER \
+            ghprbSourceBranch \
+            ghprbActualCommit \
+            BUILD_URL \
+            ghprbPullId)"
   fi
 }
 

--- a/openshift/che-tenant-maintainer.app.yml
+++ b/openshift/che-tenant-maintainer.app.yml
@@ -98,7 +98,7 @@ objects:
       app: che-tenant-maintainer
 parameters:
 - name: IMAGE
-  value: "prod.registry.devshift.net/osio-prod/fabric8-services/fabric8-tenant-che-migration"
+  value: quay.io/openshiftio/rhel-fabric8-services-fabric8-tenant-che-migration
 - name: IMAGE_TAG
   value: "latest"
 - description: Add DEBUG logs
@@ -107,4 +107,3 @@ parameters:
 - description: The Java options to run the service with
   name: JAVA_OPTIONS
   value: ""
-  


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-openshiftio/pull/952